### PR TITLE
OpenOCD cfg file for CLion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,7 @@ JLinkLog.txt
 
 # build directory
 build/
+cmake-build-debug/
 html/
 data_history/
 

--- a/boards/DJI_Board_TypeA/stlink.cfg
+++ b/boards/DJI_Board_TypeA/stlink.cfg
@@ -1,0 +1,135 @@
+# By AlchemicRonin
+
+adapter driver hla
+hla_layout stlink
+hla_device_desc "ST-LINK"
+hla_vid_pid 0x0483 0x3744 0x0483 0x3748 0x0483 0x374b 0x0483 0x374d 0x0483 0x374e 0x0483 0x374f 0x0483 0x3752 0x0483 0x3753
+
+if [catch {transport select}] {
+  echo "Error: unable to select a session transport. Can't continue."
+  shutdown
+}
+
+proc swj_newdap {chip tag args} {
+ if [using_hla] {
+     eval hla newtap $chip $tag $args
+ } elseif [using_jtag] {
+     eval jtag newtap $chip $tag $args
+ } elseif [using_swd] {
+     eval swd newdap $chip $tag $args
+ }
+}
+
+proc mrw {reg} {
+	set value ""
+	mem2array value 32 $reg 1
+	return $value(0)
+}
+
+add_usage_text mrw "address"
+add_help_text mrw "Returns value of word in memory."
+
+proc mrh {reg} {
+	set value ""
+	mem2array value 16 $reg 1
+	return $value(0)
+}
+
+add_usage_text mrh "address"
+add_help_text mrh "Returns value of halfword in memory."
+
+proc mrb {reg} {
+	set value ""
+	mem2array value 8 $reg 1
+	return $value(0)
+}
+
+add_usage_text mrb "address"
+add_help_text mrb "Returns value of byte in memory."
+
+proc mmw {reg setbits clearbits} {
+	set old [mrw $reg]
+	set new [expr ($old & ~$clearbits) | $setbits]
+	mww $reg $new
+}
+
+add_usage_text mmw "address setbits clearbits"
+add_help_text mmw "Modify word in memory. new_val = (old_val & ~clearbits) | setbits;"
+
+if { [info exists CHIPNAME] } {
+   set _CHIPNAME $CHIPNAME
+} else {
+   set _CHIPNAME stm32f4x
+}
+
+set _ENDIAN little
+
+if { [info exists WORKAREASIZE] } {
+   set _WORKAREASIZE $WORKAREASIZE
+} else {
+   set _WORKAREASIZE 0x8000
+}
+
+if { [info exists CPUTAPID] } {
+   set _CPUTAPID $CPUTAPID
+} else {
+   if { [using_jtag] } {
+      set _CPUTAPID 0x4ba00477
+   } {
+      set _CPUTAPID 0x2ba01477
+   }
+}
+
+swj_newdap $_CHIPNAME cpu -irlen 4 -ircapture 0x1 -irmask 0xf -expected-id $_CPUTAPID
+dap create $_CHIPNAME.dap -chain-position $_CHIPNAME.cpu
+
+if {[using_jtag]} {
+   jtag newtap $_CHIPNAME bs -irlen 5
+}
+
+set _TARGETNAME $_CHIPNAME.cpu
+target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap $_CHIPNAME.dap
+
+$_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
+
+set _FLASHNAME $_CHIPNAME.flash
+flash bank $_FLASHNAME stm32f2x 0 0 0 0 $_TARGETNAME
+
+flash bank $_CHIPNAME.otp stm32f2x 0x1fff7800 0 0 0 $_TARGETNAME
+
+adapter speed 2000
+
+adapter srst delay 100
+if {[using_jtag]} {
+ jtag_ntrst_delay 100
+}
+
+reset_config srst_nogate
+
+if {![using_hla]} {
+   cortex_m reset_config sysresetreq
+}
+
+$_TARGETNAME configure -event examine-end {
+	mmw 0xE0042004 0x00000007 0
+	mmw 0xE0042008 0x00001800 0
+}
+
+$_TARGETNAME configure -event trace-config {
+	mmw 0xE0042004 0x00000020 0
+}
+
+$_TARGETNAME configure -event reset-init {
+	mww 0x40023804 0x08012008   ;# RCC_PLLCFGR 16 Mhz /8 (M) * 128 (N) /4(P)
+	mww 0x40023C00 0x00000102   ;# FLASH_ACR = PRFTBE | 2(Latency)
+	mmw 0x40023800 0x01000000 0 ;# RCC_CR |= PLLON
+	sleep 10                    ;# Wait for PLL to lock
+	mmw 0x40023808 0x00001000 0 ;# RCC_CFGR |= RCC_CFGR_PPRE1_DIV2
+	mmw 0x40023808 0x00000002 0 ;# RCC_CFGR |= RCC_CFGR_SW_PLL
+
+	adapter speed 8000
+}
+
+$_TARGETNAME configure -event reset-start {
+	adapter speed 2000
+}


### PR DESCRIPTION
I integrate several convenient functions into OpenOCD.
Notice that this cfg file only works for stm32f4.
1. Run button in CLion will automatically upload compiled binary file into stm32f4.
2. Debug button in CLion will automatically connect to OpenOCD server, so we can now debug on stm32 without command line.
3. OpenOCD now can watch synchronously ALL variables in stm32f4. But to reveal them, you need to specify which variables in debugger. Also, variables currently values will automatically reveal beside its variable code.